### PR TITLE
Save space by cleaning packages from apt/dnf cache

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,9 +28,9 @@ repos:
     hooks:
     -   id: doc8
 -   repo: https://github.com/pycqa/isort
-    rev: develop
+    rev: 5.6.3
     hooks:
-    -   id: isort
+    - id: isort
 -   repo: https://github.com/pocc/pre-commit-hooks
     rev: master
     hooks:

--- a/scripts/install_linux_apt.sh
+++ b/scripts/install_linux_apt.sh
@@ -7,3 +7,4 @@
 COMPONENTS=$(echo "$1" | sed "s/,/ /g")
 #shellcheck disable=SC2086
 sudo apt-get install -y $COMPONENTS
+sudo apt-get clean

--- a/scripts/install_linux_apt_no_sudo.sh
+++ b/scripts/install_linux_apt_no_sudo.sh
@@ -6,3 +6,4 @@
 
 COMPONENTS=$(echo "$1" | sed "s/,/ /g")
 apt-get install -y "$COMPONENTS"
+apt-get clean

--- a/scripts/install_linux_dnf.sh
+++ b/scripts/install_linux_dnf.sh
@@ -7,3 +7,4 @@
 COMPONENTS=$(echo "$1" | sed "s/,/ /g")
 #shellcheck disable=SC2086
 sudo dnf -y install $COMPONENTS
+sudo dnf clean packages

--- a/scripts/install_linux_dnf_no_sudo.sh
+++ b/scripts/install_linux_dnf_no_sudo.sh
@@ -7,3 +7,4 @@
 COMPONENTS=$(echo "$1" | sed "s/,/ /g")
 #shellcheck disable=SC2086
 dnf -y install $COMPONENTS
+dnf clean packages


### PR DESCRIPTION
Free up 1 GB or more by cleaning apt/dnf package cache

isort was pegged to branch that was deleted update isort to recommended config: https://pycqa.github.io/isort/docs/configuration/pre-commit/