### PR TITLE
Fixed caching in DPC++ sample configs on Windows, fixed VS2022 builds, and more

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -40,6 +40,8 @@ variables:
     value: intel.oneapi.mac.ifort-compiler
   - name: SAMPLES_TAG
     value: 2022.1.0
+  - name: COMPILER_VERSION
+    value: 2022.0.3
 
 resources:
     containers:
@@ -123,39 +125,42 @@ jobs:
   pool:
     vmImage: 'windows-latest'
   steps:
-#  - task: Cache@2 # multiple paths per cache not supported yet. See https://github.com/microsoft/azure-pipelines-agent/pull/2834
-#    inputs:
-#      path: C:\Program Files (x86)\Intel\oneAPI\compiler
-#      key: '"install" | "$(WINDOWS_BASEKIT_URL)" | "$(WINDOWS_DPCPP_COMPONENTS)" | "compiler" | scripts/cache_exclude_windows.sh'
-#      cacheHitVar: CACHE_RESTORED
-#  - task: Cache@2
-#    condition: eq(variables.CACHE_RESTORED, 'true')
-#    inputs:
-#      path: C:\Program Files (x86)\Intel\oneAPI\tbb
-#      key: '"install" | "$(WINDOWS_BASEKIT_URL)" | "$(WINDOWS_DPCPP_COMPONENTS)" | "tbb" | scripts/cache_exclude_windows.sh'
-#      cacheHitVar: CACHE_RESTORED
-#  - task: Cache@2
-#    condition: eq(variables.CACHE_RESTORED, 'true')
-#    inputs:
-#      path: opencl # caching of individual files is not supported, caching OpenCL.dll in a folder as a workaround.
-#      key: '"install" | "$(WINDOWS_BASEKIT_URL)" | "$(WINDOWS_DPCPP_COMPONENTS)" | "opencl_folder" | scripts/cache_exclude_windows.sh'
-#      cacheHitVar: CACHE_RESTORED
+  - task: Cache@2 # multiple paths per cache not supported yet. See https://github.com/microsoft/azure-pipelines-agent/pull/2834
+    inputs:
+      path: C:\Program Files (x86)\Intel\oneAPI\compiler
+      key: '"install" | "$(WINDOWS_BASEKIT_URL)" | "$(WINDOWS_DPCPP_COMPONENTS)" | "compiler" | scripts/cache_exclude_windows.sh'
+      cacheHitVar: CACHE_RESTORED
+  - task: Cache@2
+    condition: eq(variables.CACHE_RESTORED, 'true')
+    inputs:
+      path: C:\Program Files (x86)\Intel\oneAPI\tbb
+      key: '"install" | "$(WINDOWS_BASEKIT_URL)" | "$(WINDOWS_DPCPP_COMPONENTS)" | "tbb" | scripts/cache_exclude_windows.sh'
+      cacheHitVar: CACHE_RESTORED
+  - task: Cache@2
+    condition: eq(variables.CACHE_RESTORED, 'true')
+    inputs:
+      path: opencl # caching of individual files is not supported, caching OpenCL.dll in a folder as a workaround.
+      key: '"install" | "$(WINDOWS_BASEKIT_URL)" | "$(WINDOWS_DPCPP_COMPONENTS)" | "opencl_folder" | scripts/cache_exclude_windows.sh'
+      cacheHitVar: CACHE_RESTORED
   - script: scripts/install_windows.bat $(WINDOWS_BASEKIT_URL) $(WINDOWS_DPCPP_COMPONENTS)
     displayName: install
     condition: ne(variables.CACHE_RESTORED, 'true')
+  - script: scripts/restore_registry.bat $(COMPILER_VERSION)
+    displayName: restory registry on cache hit
+    condition: eq(variables.CACHE_RESTORED, 'true')
   - bash: cp opencl/OpenCL.dll C:/Windows/System32/
     displayName: restore OpenCL.dll from cache
     condition: eq(variables.CACHE_RESTORED, 'true')
   - script: scripts/build_windows.bat dpc++ "" $(SAMPLES_TAG)
     displayName: build
-#  - bash: scripts/cache_exclude_windows.sh
-#    displayName: exclude unused files from cache
-#    condition: ne(variables.CACHE_RESTORED, 'true')
-#  - bash: |
-#      mkdir -p opencl
-#      cp C:/Windows/System32/OpenCL.dll opencl/
-#    displayName: copy OpenCL.dll to a folder for caching
-#    condition: ne(variables.CACHE_RESTORED, 'true')
+  - bash: scripts/cache_exclude_windows.sh
+    displayName: exclude unused files from cache
+    condition: ne(variables.CACHE_RESTORED, 'true')
+  - bash: |
+      mkdir -p opencl
+      cp C:/Windows/System32/OpenCL.dll opencl/
+    displayName: copy OpenCL.dll to a folder for caching
+    condition: ne(variables.CACHE_RESTORED, 'true')
 
   # Delete the following if you don't want to save install logs
   - task: CopyFiles@2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,9 @@ parameters:
   SAMPLES_TAG:
     type: string
     default: "2022.1.0"
+  COMPILER_VERSION:
+    type: string
+    default: "2022.0.3"
 
 orbs:
   win: circleci/windows@2.4.0
@@ -125,10 +128,14 @@ jobs:
       shell: bash.exe
     steps:
       - checkout
-       # Temporary turned off due to caching error
-#      - restore_cache:
-#          keys:
-#            - install-<< pipeline.parameters.WINDOWS_BASEKIT_URL >>-<< pipeline.parameters.WINDOWS_DPCPP_COMPONENTS >>-compiler-tbb-opencl-{{ checksum "scripts/cache_exclude_windows.sh" }}
+      - restore_cache:
+          keys:
+            - install-<< pipeline.parameters.WINDOWS_BASEKIT_URL >>-<< pipeline.parameters.WINDOWS_DPCPP_COMPONENTS >>-compiler-tbb-opencl-{{ checksum "scripts/cache_exclude_windows.sh" }}
+      - run:
+          name: restory registry on cache hit
+          command: |
+            [ ! -d "C:\Program Files (x86)\Intel\oneAPI\compiler" ] && exit 0
+            scripts/restore_registry.bat << pipeline.parameters.COMPILER_VERSION >>
       - run:
           name: install
           command: |
@@ -137,16 +144,15 @@ jobs:
       - run:
           name: build
           command: scripts/build_windows.bat dpc++ 2017_build_tools << pipeline.parameters.SAMPLES_TAG >>
-      # Temporary turned off due to caching error
-#      - run:
-#          name: exclude unused files from cache
-#          command: scripts/cache_exclude_windows.sh
-#      - save_cache:
-#          key: install-<< pipeline.parameters.WINDOWS_BASEKIT_URL >>-<< pipeline.parameters.WINDOWS_DPCPP_COMPONENTS >>-compiler-tbb-opencl-{{ checksum "scripts/cache_exclude_windows.sh" }}
-#          paths:
-#            - C:\Program Files (x86)\Intel\oneAPI\compiler
-#            - C:\Program Files (x86)\Intel\oneAPI\tbb
-#            - C:\Windows\System32\OpenCL.dll
+      - run:
+          name: exclude unused files from cache
+          command: scripts/cache_exclude_windows.sh
+      - save_cache:
+          key: install-<< pipeline.parameters.WINDOWS_BASEKIT_URL >>-<< pipeline.parameters.WINDOWS_DPCPP_COMPONENTS >>-compiler-tbb-opencl-{{ checksum "scripts/cache_exclude_windows.sh" }}
+          paths:
+            - C:\Program Files (x86)\Intel\oneAPI\compiler
+            - C:\Program Files (x86)\Intel\oneAPI\tbb
+            - C:\Windows\System32\OpenCL.dll
 
       # Delete the following if you don't want to save install logs
       - run:

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -23,7 +23,9 @@ env:
   LINUX_DPCPP_COMPONENTS_WEB: intel.oneapi.lin.dpcpp-cpp-compiler
   MACOS_CPP_COMPONENTS: intel.oneapi.mac.cpp-compiler
   MACOS_FORTRAN_COMPONENTS: intel.oneapi.mac.ifort-compiler
+  CACHE_NUMBER: 1
   SAMPLES_TAG: 2022.1.0
+  COMPILER_VERSION: 2022.0.3
 
 jobs:
   build_windows_cpp:
@@ -37,13 +39,15 @@ jobs:
       id: cache-install
       uses: actions/cache@v2
       with:
-        path: C:\Program Files (x86)\Intel\oneAPI\compiler
-        key: install-${{ env.WINDOWS_HPCKIT_URL }}-${{ env.WINDOWS_CPP_COMPONENTS }}-compiler-${{ hashFiles('**/scripts/cache_exclude_windows.sh') }}
+        path: |
+            C:\Program Files (x86)\Intel\oneAPI\setvars-vcvarsall.bat
+            C:\Program Files (x86)\Intel\oneAPI\compiler
+        key: install-${{ env.CACHE_NUMBER }}-${{ env.WINDOWS_HPCKIT_URL }}-${{ env.WINDOWS_CPP_COMPONENTS }}-compiler-${{ hashFiles('**/scripts/cache_exclude_windows.sh') }}
     - name: install
       if: steps.cache-install.outputs.cache-hit != 'true'
       run: scripts/install_windows.bat $WINDOWS_HPCKIT_URL $WINDOWS_CPP_COMPONENTS
     - name: build
-      run: scripts/build_windows.bat c++ "" $SAMPLES_TAG
+      run: scripts/build_windows.bat c++ 2022 $SAMPLES_TAG
     - name: exclude unused files from cache
       if: steps.cache-install.outputs.cache-hit != 'true'
       shell: bash
@@ -72,13 +76,15 @@ jobs:
       id: cache-install
       uses: actions/cache@v2
       with:
-        path: C:\Program Files (x86)\Intel\oneAPI\compiler
-        key: install-${{ env.WINDOWS_HPCKIT_URL }}-${{ env.WINDOWS_FORTRAN_COMPONENTS }}-compiler-${{ hashFiles('**/scripts/cache_exclude_windows.sh') }}
+        path: |
+            C:\Program Files (x86)\Intel\oneAPI\setvars-vcvarsall.bat
+            C:\Program Files (x86)\Intel\oneAPI\compiler
+        key: install-${{ env.CACHE_NUMBER }}-${{ env.WINDOWS_HPCKIT_URL }}-${{ env.WINDOWS_FORTRAN_COMPONENTS }}-compiler-${{ hashFiles('**/scripts/cache_exclude_windows.sh') }}
     - name: install
       if: steps.cache-install.outputs.cache-hit != 'true'
       run: scripts/install_windows.bat $WINDOWS_HPCKIT_URL $WINDOWS_FORTRAN_COMPONENTS
     - name: build
-      run: scripts/build_windows.bat fortran "" $SAMPLES_TAG
+      run: scripts/build_windows.bat fortran 2022 $SAMPLES_TAG
     - name: exclude unused files from cache
       if: steps.cache-install.outputs.cache-hit != 'true'
       shell: bash
@@ -103,26 +109,28 @@ jobs:
         shell: bash
     steps:
     - uses: actions/checkout@v2
-    # Temporary turned off due to caching error
-#    - name: cache install
-#      id: cache-install
-#      uses: actions/cache@v2
-#      with:
-#        path: |
-#          C:\Program Files (x86)\Intel\oneAPI\compiler
-#          C:\Program Files (x86)\Intel\oneAPI\tbb
-#          C:\Windows\System32\OpenCL.dll
-#        key: install-${{ env.WINDOWS_BASEKIT_URL }}-${{ env.WINDOWS_DPCPP_COMPONENTS }}-compiler-tbb-opencl-${{ hashFiles('**/scripts/cache_exclude_windows.sh') }}
+    - name: cache install
+      id: cache-install
+      uses: actions/cache@v2
+      with:
+        path: |
+          C:\Program Files (x86)\Intel\oneAPI\setvars-vcvarsall.bat
+          C:\Program Files (x86)\Intel\oneAPI\compiler
+          C:\Program Files (x86)\Intel\oneAPI\tbb
+          C:\Windows\System32\OpenCL.dll
+        key: install-${{ env.CACHE_NUMBER }}-${{ env.WINDOWS_BASEKIT_URL }}-${{ env.WINDOWS_DPCPP_COMPONENTS }}-compiler-tbb-opencl-${{ hashFiles('**/scripts/cache_exclude_windows.sh') }}
     - name: install
-#      if: steps.cache-install.outputs.cache-hit != 'true'
+      if: steps.cache-install.outputs.cache-hit != 'true'
       run: scripts/install_windows.bat $WINDOWS_BASEKIT_URL $WINDOWS_DPCPP_COMPONENTS
+    - name: restore registry on cache hit
+      if: steps.cache-install.outputs.cache-hit == 'true'
+      run: scripts/restore_registry.bat $COMPILER_VERSION
     - name: build
-      run: scripts/build_windows.bat dpc++ "" $SAMPLES_TAG
-      # Temporary turned off due to caching error
-#    - name: exclude unused files from cache
-#      if: steps.cache-install.outputs.cache-hit != 'true'
-#      shell: bash
-#      run: scripts/cache_exclude_windows.sh
+      run: scripts/build_windows.bat dpc++ 2022 $SAMPLES_TAG
+    - name: exclude unused files from cache
+      if: steps.cache-install.outputs.cache-hit != 'true'
+      shell: bash
+      run: scripts/cache_exclude_windows.sh
 
     # Delete the following if you don't want to save install logs
     - name: Saving install logs
@@ -149,7 +157,7 @@ jobs:
       with:
         path: |
           /opt/intel/oneapi/compiler
-        key: install-${{ env.LINUX_HPCKIT_URL }}-${{ env.LINUX_CPP_COMPONENTS_WEB }}-compiler-${{ hashFiles('**/scripts/cache_exclude_linux.sh') }}
+        key: install-${{ env.CACHE_NUMBER }}-${{ env.LINUX_HPCKIT_URL }}-${{ env.LINUX_CPP_COMPONENTS_WEB }}-compiler-${{ hashFiles('**/scripts/cache_exclude_linux.sh') }}
     - name: install
       if: steps.cache-install.outputs.cache-hit != 'true'
       run: scripts/install_linux.sh $LINUX_HPCKIT_URL $LINUX_CPP_COMPONENTS_WEB
@@ -183,7 +191,7 @@ jobs:
       with:
         path: |
           /opt/intel/oneapi/compiler
-        key: install-${{ env.LINUX_HPCKIT_URL }}-${{ env.LINUX_FORTRAN_COMPONENTS_WEB }}-compiler-${{ hashFiles('**/scripts/cache_exclude_linux.sh') }}
+        key: install-${{ env.CACHE_NUMBER }}-${{ env.LINUX_HPCKIT_URL }}-${{ env.LINUX_FORTRAN_COMPONENTS_WEB }}-compiler-${{ hashFiles('**/scripts/cache_exclude_linux.sh') }}
     - name: install
       if: steps.cache-install.outputs.cache-hit != 'true'
       run: scripts/install_linux.sh $LINUX_HPCKIT_URL $LINUX_FORTRAN_COMPONENTS_WEB
@@ -218,7 +226,7 @@ jobs:
         path: |
           /opt/intel/oneapi/compiler
           /opt/intel/oneapi/tbb
-        key: install-${{ env.LINUX_BASEKIT_URL }}-${{ env.LINUX_DPCPP_COMPONENTS_WEB }}-compiler-tbb-${{ hashFiles('**/scripts/cache_exclude_linux.sh') }}
+        key: install-${{ env.CACHE_NUMBER }}-${{ env.LINUX_BASEKIT_URL }}-${{ env.LINUX_DPCPP_COMPONENTS_WEB }}-compiler-tbb-${{ hashFiles('**/scripts/cache_exclude_linux.sh') }}
     - name: install
       if: steps.cache-install.outputs.cache-hit != 'true'
       run: scripts/install_linux.sh $LINUX_BASEKIT_URL $LINUX_DPCPP_COMPONENTS_WEB

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,8 +19,9 @@ variables:
   LINUX_CPP_COMPONENTS_WEB: intel.oneapi.lin.dpcpp-cpp-compiler-pro
   LINUX_FORTRAN_COMPONENTS_WEB: intel.oneapi.lin.ifort-compiler
   LINUX_DPCPP_COMPONENTS_WEB: intel.oneapi.lin.dpcpp-cpp-compiler
-  LINUX_APT_DNF_CACHE_NUMBER: 6
+  CACHE_NUMBER: 7
   SAMPLES_TAG: 2022.1.0
+  COMPILER_VERSION: 2022.0.3
 
 .shared_windows_runners:
   tags:
@@ -34,7 +35,7 @@ build_windows_cpp:
   stage: build
   cache:
     key:
-      prefix: install-${WINDOWS_HPCKIT_URL}-${WINDOWS_CPP_COMPONENTS}-compiler
+      prefix: install-${WINDOWS_CPP_COMPONENTS}-compiler
       files:
         - scripts/cache_exclude_windows.ps1
     paths:
@@ -74,7 +75,7 @@ build_windows_fortran:
   stage: build
   cache:
     key:
-      prefix: install-${WINDOWS_HPCKIT_URL}-${WINDOWS_FORTRAN_COMPONENTS}-compiler
+      prefix: install-${WINDOWS_FORTRAN_COMPONENTS}-compiler
       files:
         - scripts/cache_exclude_windows.ps1
     paths:
@@ -112,7 +113,7 @@ build_windows_dpcpp:
   stage: build
   cache:
     key:
-      prefix: install-${WINDOWS_BASEKIT_URL}-${WINDOWS_DPCPP_COMPONENTS}-compiler-tbb-opencl
+      prefix: install-${WINDOWS_DPCPP_COMPONENTS}-compiler-tbb-opencl
       files:
         - scripts/cache_exclude_windows.ps1
     paths:
@@ -124,6 +125,7 @@ build_windows_dpcpp:
           Move-Item -Path cache\compiler -Destination "C:\Program Files (x86)\Intel\oneAPI"
           Move-Item -Path cache\tbb -Destination "C:\Program Files (x86)\Intel\oneAPI"
           Move-Item -Path cache\OpenCL.dll -Destination "C:\Windows\System32"
+          scripts/restore_registry.bat $COMPILER_VERSION
         } else {
           scripts/install_windows.bat $WINDOWS_BASEKIT_URL $WINDOWS_DPCPP_COMPONENTS
         }
@@ -271,7 +273,7 @@ build_linux_apt_cpp:
   stage: build
   cache:
     key: # GitLab CI doesn't support steps before cache is restored, i.e. only static cache keys are supported.
-      prefix: install-${LINUX_APT_DNF_CACHE_NUMBER}-${LINUX_CPP_COMPONENTS}-compiler
+      prefix: install-${CACHE_NUMBER}-${LINUX_CPP_COMPONENTS}-compiler
       files:
         - scripts/cache_exclude_linux_no_sudo.sh
     paths:
@@ -303,7 +305,7 @@ build_linux_apt_fortran:
   stage: build
   cache:
     key:
-      prefix: install-${LINUX_APT_DNF_CACHE_NUMBER}-${LINUX_FORTRAN_COMPONENTS}-compiler
+      prefix: install-${CACHE_NUMBER}-${LINUX_FORTRAN_COMPONENTS}-compiler
       files:
         - scripts/cache_exclude_linux_no_sudo.sh
     paths:
@@ -335,7 +337,7 @@ build_linux_apt_dpcpp:
   stage: build
   cache:
     key:
-      prefix: install-${LINUX_APT_DNF_CACHE_NUMBER}-${LINUX_DPCPP_COMPONENTS}-compiler-tbb
+      prefix: install-${CACHE_NUMBER}-${LINUX_DPCPP_COMPONENTS}-compiler-tbb
       files:
         - scripts/cache_exclude_linux_no_sudo.sh
     paths:
@@ -369,7 +371,7 @@ build_linux_dnf_cpp:
   stage: build
   cache:
     key: # GitLab CI doesn't support steps before cache is restored, i.e. only static cache keys are supported.
-      prefix: install-${LINUX_APT_DNF_CACHE_NUMBER}-${LINUX_CPP_COMPONENTS}-compiler
+      prefix: install-${CACHE_NUMBER}-${LINUX_CPP_COMPONENTS}-compiler
       files:
         - scripts/cache_exclude_linux_no_sudo.sh
     paths:
@@ -401,7 +403,7 @@ build_linux_dnf_fortran:
   stage: build
   cache:
     key:
-      prefix: install-${LINUX_APT_DNF_CACHE_NUMBER}-${LINUX_FORTRAN_COMPONENTS}-compiler
+      prefix: install-${CACHE_NUMBER}-${LINUX_FORTRAN_COMPONENTS}-compiler
       files:
         - scripts/cache_exclude_linux_no_sudo.sh
     paths:
@@ -433,7 +435,7 @@ build_linux_dnf_dpcpp:
   stage: build
   cache:
     key:
-      prefix: install-${LINUX_APT_DNF_CACHE_NUMBER}-${LINUX_DPCPP_COMPONENTS}-compiler-tbb
+      prefix: install-${CACHE_NUMBER}-${LINUX_DPCPP_COMPONENTS}-compiler-tbb
       files:
         - scripts/cache_exclude_linux_no_sudo.sh
     paths:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,38 +9,38 @@ exclude: LICENSES
 
 repos:
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 22.1.0
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v4.1.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 4.0.1
     hooks:
     -   id: flake8
 -   repo: https://github.com/pycqa/doc8
-    rev: main
+    rev: 0.10.1
     hooks:
     -   id: doc8
 -   repo: https://github.com/pycqa/isort
-    rev: 5.6.3
+    rev: 5.10.1
     hooks:
     -   id: isort
 -   repo: https://github.com/pocc/pre-commit-hooks
-    rev: master
+    rev: v1.3.5
     hooks:
     -   id: clang-format
 -   repo: https://github.com/fsfe/reuse-tool
-    rev: master
+    rev: v0.14.0
     hooks:
     -   id: reuse
 -   repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.7.1.1
+    rev: v0.8.0.4
     hooks:
     -   id: shellcheck
         args: [-x, --exclude=SC2001, --exclude=SC2164, --exclude=SC1091]

--- a/scripts/build_windows.bat
+++ b/scripts/build_windows.bat
@@ -1,4 +1,4 @@
-REM SPDX-FileCopyrightText: 2020 Intel Corporation
+REM SPDX-FileCopyrightText: 2022 Intel Corporation
 REM
 REM SPDX-License-Identifier: MIT
 
@@ -13,6 +13,11 @@ IF "%VS_VER%"=="2017_build_tools" (
 IF "%VS_VER%"=="2019_build_tools" (
 @call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
 )
+
+IF "%VS_VER%"=="2022" (
+@call "C:\Program Files (x86)\Intel\oneAPI\setvars-vcvarsall.bat" vs2022
+)
+
 for /f "tokens=* usebackq" %%f in (`dir /b "C:\Program Files (x86)\Intel\oneAPI\compiler\" ^| findstr /V latest ^| sort`) do @set "LATEST_VERSION=%%f"
 @call "C:\Program Files (x86)\Intel\oneAPI\compiler\%LATEST_VERSION%\env\vars.bat"
 

--- a/scripts/install_linux_apt.sh
+++ b/scripts/install_linux_apt.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2020 Intel Corporation
+# SPDX-FileCopyrightText: 2022 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 COMPONENTS=$(echo "$1" | sed "s/,/ /g")
 #shellcheck disable=SC2086
 sudo apt-get install -y $COMPONENTS
-sudo apt-get clean

--- a/scripts/install_linux_apt_no_sudo.sh
+++ b/scripts/install_linux_apt_no_sudo.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2020 Intel Corporation
+# SPDX-FileCopyrightText: 2022 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 COMPONENTS=$(echo "$1" | sed "s/,/ /g")
 apt-get install -y "$COMPONENTS"
-apt-get clean

--- a/scripts/install_linux_dnf.sh
+++ b/scripts/install_linux_dnf.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2020 Intel Corporation
+# SPDX-FileCopyrightText: 2022 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 COMPONENTS=$(echo "$1" | sed "s/,/ /g")
 #shellcheck disable=SC2086
 sudo dnf -y install $COMPONENTS
-sudo dnf clean packages

--- a/scripts/install_linux_dnf_no_sudo.sh
+++ b/scripts/install_linux_dnf_no_sudo.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2020 Intel Corporation
+# SPDX-FileCopyrightText: 2022 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 COMPONENTS=$(echo "$1" | sed "s/,/ /g")
 #shellcheck disable=SC2086
 dnf -y install $COMPONENTS
-dnf clean packages

--- a/scripts/install_macos.sh
+++ b/scripts/install_macos.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2020 Intel Corporation
+# SPDX-FileCopyrightText: 2022 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -10,7 +10,7 @@ COMPONENTS=$2
 curl --output webimage.dmg --url "$URL" --retry 5 --retry-delay 5
 hdiutil attach webimage.dmg
 if [ -z "$COMPONENTS" ]; then
-  sudo /Volumes/"$(basename "$URL" .dmg)"/bootstrapper.app/Contents/MacOS/bootstrapper -s --action install --eula=accept --continue-with-optional-error=yes --log-dir=.
+  sudo /Volumes/"$(basename "$URL" .dmg)"/bootstrapper.app/Contents/MacOS/bootstrapper -s --action install --eula=accept --log-dir=.
   installer_exit_code=$?
 else
   sudo /Volumes/"$(basename "$URL" .dmg)"/bootstrapper.app/Contents/MacOS/bootstrapper -s --action install --components="$COMPONENTS" --eula=accept --log-dir=.

--- a/scripts/install_windows.bat
+++ b/scripts/install_windows.bat
@@ -1,15 +1,16 @@
-REM SPDX-FileCopyrightText: 2020 Intel Corporation
+REM SPDX-FileCopyrightText: 2022 Intel Corporation
 REM
 REM SPDX-License-Identifier: MIT
 
 set URL=%1
 set COMPONENTS=%2
 
-curl.exe --output webimage.exe --url %URL% --retry 5 --retry-delay 5
-start /b /wait webimage.exe -s -x -f webimage_extracted --log extract.log
-del webimage.exe
+curl.exe --output %TEMP%\webimage.exe --url %URL% --retry 5 --retry-delay 5
+start /b /wait %TEMP%\webimage.exe -s -x -f webimage_extracted --log extract.log
+del %TEMP%\webimage.exe
 if "%COMPONENTS%"=="" (
-  webimage_extracted\bootstrapper.exe -s --action install --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 --log-dir=.
+  webimage_extracted\bootstrapper.exe -s --action install --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 -p=NEED_VS2022_INTEGRATION=0 --log-dir=.
 ) else (
-  webimage_extracted\bootstrapper.exe -s --action install --components=%COMPONENTS% --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 --log-dir=.
+  webimage_extracted\bootstrapper.exe -s --action install --components=%COMPONENTS% --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 -p=NEED_VS2022_INTEGRATION=0 --log-dir=.
 )
+rd /s/q "webimage_extracted"

--- a/scripts/restore_registry.bat
+++ b/scripts/restore_registry.bat
@@ -1,0 +1,7 @@
+REM SPDX-FileCopyrightText: 2022 Intel Corporation
+REM
+REM SPDX-License-Identifier: MIT
+
+set COMPILER_VERSION=%1
+
+reg add HKLM\Software\Khronos\OpenCL\Vendors /v "C:\Program Files (x86)\Intel\oneAPI\compiler\%COMPILER_VERSION%\windows\lib\x64\intelocl64.dll" /t REG_DWORD /d 0 /f


### PR DESCRIPTION
1) Fixed caching in DPC++ sample configs on Windows. CI systems don't support Windows registry caching, but there's a special key that DPC++ runtime requires in order to detect CPU device. Now that key is added explicitly in case of cache hit.
2) Fixed issues with Visual Studio 2022 command line builds in sample configs for GitHub Actions. Also disabled integration to Visual Studio 2022 to speed up installation.
3) Fixed cache key naming (removed unsupported characters).
4) Removed post-install apt/dnf cache clean-up to speed up jobs a bit.
4) Updated pre-commit hooks.
5) Updated copyrights.