### PR TITLE
Replaced references to the old oneAPI Base and HPC Toolkit URLs with the new unified oneAPI Toolkit.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,10 +4,8 @@
 
 environment:
   global:
-    WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/1f18901e-877d-469d-a41a-a10f11b39336/intel-oneapi-base-toolkit-2025.3.0.372_offline.exe
-    WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/3a871580-f839-46ed-aeae-685084127279/intel-oneapi-hpc-toolkit-2025.3.0.378_offline.exe
-    LINUX_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/d640da34-77cc-4ab2-8019-ac5592f4ec19/intel-oneapi-base-toolkit-2025.3.0.375_offline.sh
-    LINUX_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/66021d90-934d-41f4-bedf-b8c00bbe98bc/intel-oneapi-hpc-toolkit-2025.3.0.381_offline.sh
+    WINDOWS_TOOLKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/bae85ab1-cfcd-4251-8d42-a0c27949ea33/intel-oneapi-toolkit-2026.0.0.193_offline.exe
+    LINUX_TOOLKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/71180075-e4e3-4c6f-bbbb-19017ed0cf7d/intel-oneapi-toolkit-2026.0.0.198_offline.sh
     WINDOWS_CPP_COMPONENTS: intel.oneapi.win.cpp-dpcpp-common
     WINDOWS_FORTRAN_COMPONENTS: intel.oneapi.win.ifort-compiler
     WINDOWS_DPCPP_COMPONENTS: intel.oneapi.win.cpp-dpcpp-common
@@ -17,7 +15,7 @@ environment:
     LINUX_CPP_COMPONENTS_WEB: intel.oneapi.lin.dpcpp-cpp-compiler
     LINUX_FORTRAN_COMPONENTS_WEB: intel.oneapi.lin.ifort-compiler
     LINUX_DPCPP_COMPONENTS_WEB: intel.oneapi.lin.dpcpp-cpp-compiler
-    SAMPLES_TAG: 2025.3.0
+    SAMPLES_TAG: master
     VS_VER: vs2019
 
   matrix:
@@ -54,7 +52,7 @@ for:
       only:
         - job_name: build_windows_cpp
     install:
-      cmd: scripts/install_windows.bat %WINDOWS_HPCKIT_URL% %WINDOWS_CPP_COMPONENTS%
+      cmd: scripts/install_windows.bat %WINDOWS_TOOLKIT_URL% %WINDOWS_CPP_COMPONENTS%
     build_script:
       cmd: scripts/build_windows.bat c++ %VS_VER% %SAMPLES_TAG%
 
@@ -70,7 +68,7 @@ for:
       only:
         - job_name: build_windows_fortran
     install:
-      cmd: scripts/install_windows.bat %WINDOWS_HPCKIT_URL% %WINDOWS_FORTRAN_COMPONENTS%
+      cmd: scripts/install_windows.bat %WINDOWS_TOOLKIT_URL% %WINDOWS_FORTRAN_COMPONENTS%
     build_script:
       cmd: scripts/build_windows.bat fortran %VS_VER% %SAMPLES_TAG%
 
@@ -86,7 +84,7 @@ for:
       only:
         - job_name: build_windows_dpcpp
     install:
-      cmd: scripts/install_windows.bat %WINDOWS_BASEKIT_URL% %WINDOWS_DPCPP_COMPONENTS%
+      cmd: scripts/install_windows.bat %WINDOWS_TOOLKIT_URL% %WINDOWS_DPCPP_COMPONENTS%
     build_script:
       cmd: scripts/build_windows.bat dpc++ %VS_VER% %SAMPLES_TAG%
 
@@ -103,7 +101,7 @@ for:
         - job_name: build_linux_cpp
     install:
       sh: |
-        scripts/install_linux.sh $LINUX_HPCKIT_URL $LINUX_CPP_COMPONENTS_WEB
+        scripts/install_linux.sh $LINUX_TOOLKIT_URL $LINUX_CPP_COMPONENTS_WEB
     build_script:
       sh: scripts/build_linux.sh c++ $SAMPLES_TAG
 
@@ -121,7 +119,7 @@ for:
         - job_name: build_linux_fortran
     install:
       sh: |
-        scripts/install_linux.sh $LINUX_HPCKIT_URL $LINUX_FORTRAN_COMPONENTS_WEB
+        scripts/install_linux.sh $LINUX_TOOLKIT_URL $LINUX_FORTRAN_COMPONENTS_WEB
     build_script:
       sh: scripts/build_linux.sh fortran $SAMPLES_TAG
 
@@ -139,7 +137,7 @@ for:
         - job_name: build_linux_dpcpp
     install:
       sh: |
-        scripts/install_linux.sh $LINUX_BASEKIT_URL $LINUX_DPCPP_COMPONENTS_WEB
+        scripts/install_linux.sh $LINUX_TOOLKIT_URL $LINUX_DPCPP_COMPONENTS_WEB
     build_script:
       sh: scripts/build_linux.sh dpc++ $SAMPLES_TAG
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -6,14 +6,10 @@ trigger:
 - master
 
 variables:
-  - name: WINDOWS_BASEKIT_URL
-    value: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/1f18901e-877d-469d-a41a-a10f11b39336/intel-oneapi-base-toolkit-2025.3.0.372_offline.exe
-  - name: WINDOWS_HPCKIT_URL
-    value: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/3a871580-f839-46ed-aeae-685084127279/intel-oneapi-hpc-toolkit-2025.3.0.378_offline.exe
-  - name: LINUX_BASEKIT_URL
-    value: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/d640da34-77cc-4ab2-8019-ac5592f4ec19/intel-oneapi-base-toolkit-2025.3.0.375_offline.sh
-  - name: LINUX_HPCKIT_URL
-    value: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/66021d90-934d-41f4-bedf-b8c00bbe98bc/intel-oneapi-hpc-toolkit-2025.3.0.381_offline.sh
+  - name: WINDOWS_TOOLKIT_URL
+    value: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/bae85ab1-cfcd-4251-8d42-a0c27949ea33/intel-oneapi-toolkit-2026.0.0.193_offline.exe
+  - name: LINUX_TOOLKIT_URL
+    value: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/71180075-e4e3-4c6f-bbbb-19017ed0cf7d/intel-oneapi-toolkit-2026.0.0.198_offline.sh
   - name: WINDOWS_CPP_COMPONENTS
     value: intel.oneapi.win.cpp-dpcpp-common
   - name: WINDOWS_FORTRAN_COMPONENTS
@@ -33,21 +29,18 @@ variables:
   - name: LINUX_DPCPP_COMPONENTS_WEB
     value: intel.oneapi.lin.dpcpp-cpp-compiler
   - name: SAMPLES_TAG
-    value: 2025.1.0
+    value: master
   - name: COMPILER_VERSION
-    value: 2025.3
+    value: 2026.0
   - name: TBB_VERSION
-    value: 2022.3
+    value: 2023.0
   - name: VS_VER
     value: vs2022
 
 resources:
     containers:
-      - container: oneapi-hpckit
-        image: intel/oneapi-hpckit:latest
-        options: '-v /usr/bin/sudo:/usr/bin/sudo -v /usr/lib/sudo/libsudo_util.so.0:/usr/lib/sudo/libsudo_util.so.0 -v /usr/lib/sudo/sudoers.so:/usr/lib/sudo/sudoers.so'
-      - container: oneapi-basekit
-        image: intel/oneapi-basekit:latest
+      - container: oneapi-toolkit
+        image: intel/oneapi-toolkit:latest
         options: '-v /usr/bin/sudo:/usr/bin/sudo -v /usr/lib/sudo/libsudo_util.so.0:/usr/lib/sudo/libsudo_util.so.0 -v /usr/lib/sudo/sudoers.so:/usr/lib/sudo/sudoers.so'
 
 jobs:
@@ -58,15 +51,15 @@ jobs:
   - task: Cache@2 # multiple paths per cache not supported yet. See https://github.com/microsoft/azure-pipelines-agent/pull/2834
     inputs:
       path: vcvarsall
-      key: '"install" | "$(WINDOWS_HPCKIT_URL)" | "$(WINDOWS_CPP_COMPONENTS)" | "vcvarsall" | scripts/cache_exclude_windows.sh'
+      key: '"install" | "$(WINDOWS_TOOLKIT_URL)" | "$(WINDOWS_CPP_COMPONENTS)" | "vcvarsall" | scripts/cache_exclude_windows.sh'
       cacheHitVar: CACHE_RESTORED
   - task: Cache@2
     condition: eq(variables.CACHE_RESTORED, 'true')
     inputs:
       path: C:\Program Files (x86)\Intel\oneAPI\compiler
-      key: '"install" | "$(WINDOWS_HPCKIT_URL)" | "$(WINDOWS_CPP_COMPONENTS)" | "compiler" | scripts/cache_exclude_windows.sh'
+      key: '"install" | "$(WINDOWS_TOOLKIT_URL)" | "$(WINDOWS_CPP_COMPONENTS)" | "compiler" | scripts/cache_exclude_windows.sh'
       cacheHitVar: CACHE_RESTORED
-  - script: scripts/install_windows.bat $(WINDOWS_HPCKIT_URL) $(WINDOWS_CPP_COMPONENTS)
+  - script: scripts/install_windows.bat $(WINDOWS_TOOLKIT_URL) $(WINDOWS_CPP_COMPONENTS)
     displayName: install
     condition: ne(variables.CACHE_RESTORED, 'true')
   - bash: cp vcvarsall/setvars-vcvarsall.bat "C:/Program Files (x86)/Intel/oneAPI/"
@@ -106,15 +99,15 @@ jobs:
   - task: Cache@2 # multiple paths per cache not supported yet. See https://github.com/microsoft/azure-pipelines-agent/pull/2834
     inputs:
       path: vcvarsall
-      key: '"install" | "$(WINDOWS_HPCKIT_URL)" | "$(WINDOWS_FORTRAN_COMPONENTS)" | "vcvarsall" | scripts/cache_exclude_windows.sh'
+      key: '"install" | "$(WINDOWS_TOOLKIT_URL)" | "$(WINDOWS_FORTRAN_COMPONENTS)" | "vcvarsall" | scripts/cache_exclude_windows.sh'
       cacheHitVar: CACHE_RESTORED
   - task: Cache@2
     condition: eq(variables.CACHE_RESTORED, 'true')
     inputs:
       path: C:\Program Files (x86)\Intel\oneAPI\compiler
-      key: '"install" | "$(WINDOWS_HPCKIT_URL)" | "$(WINDOWS_FORTRAN_COMPONENTS)" | "compiler" | scripts/cache_exclude_windows.sh'
+      key: '"install" | "$(WINDOWS_TOOLKIT_URL)" | "$(WINDOWS_FORTRAN_COMPONENTS)" | "compiler" | scripts/cache_exclude_windows.sh'
       cacheHitVar: CACHE_RESTORED
-  - script: scripts/install_windows.bat $(WINDOWS_HPCKIT_URL) $(WINDOWS_FORTRAN_COMPONENTS)
+  - script: scripts/install_windows.bat $(WINDOWS_TOOLKIT_URL) $(WINDOWS_FORTRAN_COMPONENTS)
     displayName: install
     condition: ne(variables.CACHE_RESTORED, 'true')
   - bash: cp vcvarsall/setvars-vcvarsall.bat "C:/Program Files (x86)/Intel/oneAPI/"
@@ -154,27 +147,27 @@ jobs:
   - task: Cache@2 # multiple paths per cache not supported yet. See https://github.com/microsoft/azure-pipelines-agent/pull/2834
     inputs:
       path: vcvarsall
-      key: '"install" | "$(WINDOWS_BASEKIT_URL)" | "$(WINDOWS_DPCPP_COMPONENTS)" | "vcvarsall" | scripts/cache_exclude_windows.sh'
+      key: '"install" | "$(WINDOWS_TOOLKIT_URL)" | "$(WINDOWS_DPCPP_COMPONENTS)" | "vcvarsall" | scripts/cache_exclude_windows.sh'
       cacheHitVar: CACHE_RESTORED
   - task: Cache@2
     condition: eq(variables.CACHE_RESTORED, 'true')
     inputs:
       path: C:\Program Files (x86)\Intel\oneAPI\compiler
-      key: '"install" | "$(WINDOWS_BASEKIT_URL)" | "$(WINDOWS_DPCPP_COMPONENTS)" | "compiler" | scripts/cache_exclude_windows.sh'
+      key: '"install" | "$(WINDOWS_TOOLKIT_URL)" | "$(WINDOWS_DPCPP_COMPONENTS)" | "compiler" | scripts/cache_exclude_windows.sh'
       cacheHitVar: CACHE_RESTORED
   - task: Cache@2
     condition: eq(variables.CACHE_RESTORED, 'true')
     inputs:
       path: C:\Program Files (x86)\Intel\oneAPI\tbb
-      key: '"install" | "$(WINDOWS_BASEKIT_URL)" | "$(WINDOWS_DPCPP_COMPONENTS)" | "tbb" | scripts/cache_exclude_windows.sh'
+      key: '"install" | "$(WINDOWS_TOOLKIT_URL)" | "$(WINDOWS_DPCPP_COMPONENTS)" | "tbb" | scripts/cache_exclude_windows.sh'
       cacheHitVar: CACHE_RESTORED
   - task: Cache@2
     condition: eq(variables.CACHE_RESTORED, 'true')
     inputs:
       path: opencl # caching of individual files is not supported, caching OpenCL.dll in a folder as a workaround.
-      key: '"install" | "$(WINDOWS_BASEKIT_URL)" | "$(WINDOWS_DPCPP_COMPONENTS)" | "opencl_folder" | scripts/cache_exclude_windows.sh'
+      key: '"install" | "$(WINDOWS_TOOLKIT_URL)" | "$(WINDOWS_DPCPP_COMPONENTS)" | "opencl_folder" | scripts/cache_exclude_windows.sh'
       cacheHitVar: CACHE_RESTORED
-  - script: scripts/install_windows.bat $(WINDOWS_BASEKIT_URL) $(WINDOWS_DPCPP_COMPONENTS)
+  - script: scripts/install_windows.bat $(WINDOWS_TOOLKIT_URL) $(WINDOWS_DPCPP_COMPONENTS)
     displayName: install
     condition: ne(variables.CACHE_RESTORED, 'true')
   - script: scripts/restore_registry.bat $(COMPILER_VERSION) $(TBB_VERSION)
@@ -225,9 +218,9 @@ jobs:
   - task: Cache@2
     inputs:
       path: /opt/intel/oneapi/compiler
-      key: '"install" | "$(LINUX_HPCKIT_URL)" | "$(LINUX_CPP_COMPONENTS_WEB)" | "compiler" | scripts/cache_exclude_linux.sh'
+      key: '"install" | "$(LINUX_TOOLKIT_URL)" | "$(LINUX_CPP_COMPONENTS_WEB)" | "compiler" | scripts/cache_exclude_linux.sh'
       cacheHitVar: CACHE_RESTORED
-  - script: scripts/install_linux.sh $(LINUX_HPCKIT_URL) $(LINUX_CPP_COMPONENTS_WEB)
+  - script: scripts/install_linux.sh $(LINUX_TOOLKIT_URL) $(LINUX_CPP_COMPONENTS_WEB)
     displayName: install
     condition: ne(variables.CACHE_RESTORED, 'true')
   - script: scripts/build_linux.sh c++ $(SAMPLES_TAG)
@@ -259,9 +252,9 @@ jobs:
   - task: Cache@2
     inputs:
       path: /opt/intel/oneapi/compiler
-      key: '"install" | "$(LINUX_HPCKIT_URL)" | "$(LINUX_FORTRAN_COMPONENTS_WEB)" | "compiler" | scripts/cache_exclude_linux.sh'
+      key: '"install" | "$(LINUX_TOOLKIT_URL)" | "$(LINUX_FORTRAN_COMPONENTS_WEB)" | "compiler" | scripts/cache_exclude_linux.sh'
       cacheHitVar: CACHE_RESTORED
-  - script: scripts/install_linux.sh $(LINUX_HPCKIT_URL) $(LINUX_FORTRAN_COMPONENTS_WEB)
+  - script: scripts/install_linux.sh $(LINUX_TOOLKIT_URL) $(LINUX_FORTRAN_COMPONENTS_WEB)
     displayName: install
     condition: ne(variables.CACHE_RESTORED, 'true')
   - script: scripts/build_linux.sh fortran $(SAMPLES_TAG)
@@ -293,13 +286,13 @@ jobs:
   - task: Cache@2
     inputs:
       path: /opt/intel/oneapi/compiler
-      key: '"install" | "$(LINUX_BASEKIT_URL)" | "$(LINUX_DPCPP_COMPONENTS_WEB)" | "compiler" | scripts/cache_exclude_linux.sh'
+      key: '"install" | "$(LINUX_TOOLKIT_URL)" | "$(LINUX_DPCPP_COMPONENTS_WEB)" | "compiler" | scripts/cache_exclude_linux.sh'
   - task: Cache@2
     inputs:
       path: /opt/intel/oneapi/tbb
-      key: '"install" | "$(LINUX_BASEKIT_URL)" | "$(LINUX_DPCPP_COMPONENTS_WEB)" | "tbb" | scripts/cache_exclude_linux.sh'
+      key: '"install" | "$(LINUX_TOOLKIT_URL)" | "$(LINUX_DPCPP_COMPONENTS_WEB)" | "tbb" | scripts/cache_exclude_linux.sh'
       cacheHitVar: CACHE_RESTORED
-  - script: scripts/install_linux.sh $(LINUX_BASEKIT_URL) $(LINUX_DPCPP_COMPONENTS_WEB)
+  - script: scripts/install_linux.sh $(LINUX_TOOLKIT_URL) $(LINUX_DPCPP_COMPONENTS_WEB)
     displayName: install
     condition: ne(variables.CACHE_RESTORED, 'true')
   - script: scripts/build_linux.sh dpc++ $(SAMPLES_TAG)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,7 +377,7 @@ jobs:
 
   build_linux_dnf_cpp:
     docker:
-      - image: fedora:37
+      - image: fedora:43
     steps:
       - checkout
       - run:
@@ -410,7 +410,7 @@ jobs:
 
   build_linux_dnf_fortran:
     docker:
-      - image: fedora:37
+      - image: fedora:43
     steps:
       - checkout
       - run:
@@ -443,7 +443,7 @@ jobs:
 
   build_linux_dnf_dpcpp:
     docker:
-      - image: fedora:37
+      - image: fedora:43
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,18 +4,12 @@
 
 version: 2.1
 parameters:
-  WINDOWS_BASEKIT_URL:
+  WINDOWS_TOOLKIT_URL:
     type: string
-    default: "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/1f18901e-877d-469d-a41a-a10f11b39336/intel-oneapi-base-toolkit-2025.3.0.372_offline.exe"
-  WINDOWS_HPCKIT_URL:
+    default: "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/bae85ab1-cfcd-4251-8d42-a0c27949ea33/intel-oneapi-toolkit-2026.0.0.193_offline.exe"
+  LINUX_TOOLKIT_URL:
     type: string
-    default: "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/3a871580-f839-46ed-aeae-685084127279/intel-oneapi-hpc-toolkit-2025.3.0.378_offline.exe"
-  LINUX_BASEKIT_URL:
-    type: string
-    default: "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/d640da34-77cc-4ab2-8019-ac5592f4ec19/intel-oneapi-base-toolkit-2025.3.0.375_offline.sh"
-  LINUX_HPCKIT_URL:
-    type: string
-    default: "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/66021d90-934d-41f4-bedf-b8c00bbe98bc/intel-oneapi-hpc-toolkit-2025.3.0.381_offline.sh"
+    default: "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/71180075-e4e3-4c6f-bbbb-19017ed0cf7d/intel-oneapi-toolkit-2026.0.0.198_offline.sh"
   WINDOWS_CPP_COMPONENTS:
     type: string
     default: "intel.oneapi.win.cpp-dpcpp-common"
@@ -45,13 +39,13 @@ parameters:
     default: "intel.oneapi.lin.dpcpp-cpp-compiler"
   SAMPLES_TAG:
     type: string
-    default: "2025.3.0"
+    default: "master"
   COMPILER_VERSION:
     type: string
-    default: "2025.3"
+    default: "2026.0"
   TBB_VERSION:
     type: string
-    default: "2022.3"
+    default: "2023.0"
   VS_VER:
     type: string
     default: "vs2017"
@@ -68,12 +62,12 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - install-<< pipeline.parameters.WINDOWS_HPCKIT_URL >>-<< pipeline.parameters.WINDOWS_CPP_COMPONENTS >>-compiler-vcvarsall-{{ checksum "scripts/cache_exclude_windows.sh" }}
+            - install-<< pipeline.parameters.WINDOWS_TOOLKIT_URL >>-<< pipeline.parameters.WINDOWS_CPP_COMPONENTS >>-compiler-vcvarsall-{{ checksum "scripts/cache_exclude_windows.sh" }}
       - run:
           name: install
           command: |
             [ -d "C:\Program Files (x86)\Intel\oneAPI\compiler" ] && exit 0
-            scripts/install_windows.bat << pipeline.parameters.WINDOWS_HPCKIT_URL >> << pipeline.parameters.WINDOWS_CPP_COMPONENTS >>
+            scripts/install_windows.bat << pipeline.parameters.WINDOWS_TOOLKIT_URL >> << pipeline.parameters.WINDOWS_CPP_COMPONENTS >>
       - run:
           name: build
           command: scripts/build_windows.bat c++ << pipeline.parameters.VS_VER >> << pipeline.parameters.SAMPLES_TAG >>
@@ -81,7 +75,7 @@ jobs:
           name: exclude unused files from cache
           command: scripts/cache_exclude_windows.sh
       - save_cache:
-          key: install-<< pipeline.parameters.WINDOWS_HPCKIT_URL >>-<< pipeline.parameters.WINDOWS_CPP_COMPONENTS >>-compiler-{{ checksum "scripts/cache_exclude_windows.sh" }}
+          key: install-<< pipeline.parameters.WINDOWS_TOOLKIT_URL >>-<< pipeline.parameters.WINDOWS_CPP_COMPONENTS >>-compiler-{{ checksum "scripts/cache_exclude_windows.sh" }}
           paths:
             - C:\Program Files (x86)\Intel\oneAPI\compiler
             - C:\Program Files (x86)\Intel\oneAPI\setvars-vcvarsall.bat
@@ -103,12 +97,12 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - install-<< pipeline.parameters.WINDOWS_HPCKIT_URL >>-<< pipeline.parameters.WINDOWS_FORTRAN_COMPONENTS >>-compiler-vcvarsall-{{ checksum "scripts/cache_exclude_windows.sh" }}
+            - install-<< pipeline.parameters.WINDOWS_TOOLKIT_URL >>-<< pipeline.parameters.WINDOWS_FORTRAN_COMPONENTS >>-compiler-vcvarsall-{{ checksum "scripts/cache_exclude_windows.sh" }}
       - run:
           name: install
           command: |
             [ -d "C:\Program Files (x86)\Intel\oneAPI\compiler" ] && exit 0
-            scripts/install_windows.bat << pipeline.parameters.WINDOWS_HPCKIT_URL >> << pipeline.parameters.WINDOWS_FORTRAN_COMPONENTS >>
+            scripts/install_windows.bat << pipeline.parameters.WINDOWS_TOOLKIT_URL >> << pipeline.parameters.WINDOWS_FORTRAN_COMPONENTS >>
       - run:
           name: build
           command: scripts/build_windows.bat fortran << pipeline.parameters.VS_VER >> << pipeline.parameters.SAMPLES_TAG >>
@@ -116,7 +110,7 @@ jobs:
           name: exclude unused files from cache
           command: scripts/cache_exclude_windows.sh
       - save_cache:
-          key: install-<< pipeline.parameters.WINDOWS_HPCKIT_URL >>-<< pipeline.parameters.WINDOWS_FORTRAN_COMPONENTS >>-compiler-{{ checksum "scripts/cache_exclude_windows.sh" }}
+          key: install-<< pipeline.parameters.WINDOWS_TOOLKIT_URL >>-<< pipeline.parameters.WINDOWS_FORTRAN_COMPONENTS >>-compiler-{{ checksum "scripts/cache_exclude_windows.sh" }}
           paths:
             - C:\Program Files (x86)\Intel\oneAPI\compiler
             - C:\Program Files (x86)\Intel\oneAPI\setvars-vcvarsall.bat
@@ -138,7 +132,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - install-<< pipeline.parameters.WINDOWS_BASEKIT_URL >>-<< pipeline.parameters.WINDOWS_DPCPP_COMPONENTS >>-compiler-tbb-opencl-vcvarsall-{{ checksum "scripts/cache_exclude_windows.sh" }}
+            - install-<< pipeline.parameters.WINDOWS_TOOLKIT_URL >>-<< pipeline.parameters.WINDOWS_DPCPP_COMPONENTS >>-compiler-tbb-opencl-vcvarsall-{{ checksum "scripts/cache_exclude_windows.sh" }}
       - run:
           name: restory registry on cache hit
           command: |
@@ -148,7 +142,7 @@ jobs:
           name: install
           command: |
             [ -d "C:\Program Files (x86)\Intel\oneAPI\compiler" ] && exit 0
-            scripts/install_windows.bat << pipeline.parameters.WINDOWS_BASEKIT_URL >> << pipeline.parameters.WINDOWS_DPCPP_COMPONENTS >>
+            scripts/install_windows.bat << pipeline.parameters.WINDOWS_TOOLKIT_URL >> << pipeline.parameters.WINDOWS_DPCPP_COMPONENTS >>
       - run:
           name: build
           command: scripts/build_windows.bat dpc++ << pipeline.parameters.VS_VER >> << pipeline.parameters.SAMPLES_TAG >>
@@ -156,7 +150,7 @@ jobs:
           name: exclude unused files from cache
           command: scripts/cache_exclude_windows.sh
       - save_cache:
-          key: install-<< pipeline.parameters.WINDOWS_BASEKIT_URL >>-<< pipeline.parameters.WINDOWS_DPCPP_COMPONENTS >>-compiler-tbb-opencl-{{ checksum "scripts/cache_exclude_windows.sh" }}
+          key: install-<< pipeline.parameters.WINDOWS_TOOLKIT_URL >>-<< pipeline.parameters.WINDOWS_DPCPP_COMPONENTS >>-compiler-tbb-opencl-{{ checksum "scripts/cache_exclude_windows.sh" }}
           paths:
             - C:\Program Files (x86)\Intel\oneAPI\compiler
             - C:\Program Files (x86)\Intel\oneAPI\tbb
@@ -182,12 +176,12 @@ jobs:
           command: . scripts/install_prerequisites_linux_no_sudo.sh
       - restore_cache:
           keys:
-            - install-<< pipeline.parameters.LINUX_HPCKIT_URL >>-<< pipeline.parameters.LINUX_CPP_COMPONENTS_WEB >>-compiler-${{ checksum "scripts/cache_exclude_linux_no_sudo.sh" }}
+            - install-<< pipeline.parameters.LINUX_TOOLKIT_URL >>-<< pipeline.parameters.LINUX_CPP_COMPONENTS_WEB >>-compiler-${{ checksum "scripts/cache_exclude_linux_no_sudo.sh" }}
       - run:
           name: install
           command: |
            [ -d /opt/intel/oneapi/compiler ] && exit 0
-           . scripts/install_linux_no_sudo.sh << pipeline.parameters.LINUX_HPCKIT_URL >> << pipeline.parameters.LINUX_CPP_COMPONENTS_WEB >>
+           . scripts/install_linux_no_sudo.sh << pipeline.parameters.LINUX_TOOLKIT_URL >> << pipeline.parameters.LINUX_CPP_COMPONENTS_WEB >>
       - run:
           name: build
           command: scripts/build_linux.sh c++ << pipeline.parameters.SAMPLES_TAG >>
@@ -195,7 +189,7 @@ jobs:
           name: exclude unused files from cache
           command: . scripts/cache_exclude_linux_no_sudo.sh
       - save_cache:
-          key: install-<< pipeline.parameters.LINUX_HPCKIT_URL >>-<< pipeline.parameters.LINUX_CPP_COMPONENTS_WEB >>-compiler-${{ checksum "scripts/cache_exclude_linux_no_sudo.sh" }}
+          key: install-<< pipeline.parameters.LINUX_TOOLKIT_URL >>-<< pipeline.parameters.LINUX_CPP_COMPONENTS_WEB >>-compiler-${{ checksum "scripts/cache_exclude_linux_no_sudo.sh" }}
           paths:
             - /opt/intel/oneapi/compiler
 
@@ -218,12 +212,12 @@ jobs:
           command: . scripts/install_prerequisites_linux_no_sudo.sh
       - restore_cache:
           keys:
-            - install-<< pipeline.parameters.LINUX_HPCKIT_URL >>-<< pipeline.parameters.LINUX_FORTRAN_COMPONENTS_WEB >>-compiler-${{ checksum "scripts/cache_exclude_linux_no_sudo.sh" }}
+            - install-<< pipeline.parameters.LINUX_TOOLKIT_URL >>-<< pipeline.parameters.LINUX_FORTRAN_COMPONENTS_WEB >>-compiler-${{ checksum "scripts/cache_exclude_linux_no_sudo.sh" }}
       - run:
           name: install
           command: |
            [ -d /opt/intel/oneapi/compiler ] && exit 0
-           . scripts/install_linux_no_sudo.sh << pipeline.parameters.LINUX_HPCKIT_URL >> << pipeline.parameters.LINUX_FORTRAN_COMPONENTS_WEB >>
+           . scripts/install_linux_no_sudo.sh << pipeline.parameters.LINUX_TOOLKIT_URL >> << pipeline.parameters.LINUX_FORTRAN_COMPONENTS_WEB >>
       - run:
           name: build
           command: scripts/build_linux.sh fortran << pipeline.parameters.SAMPLES_TAG >>
@@ -231,7 +225,7 @@ jobs:
           name: exclude unused files from cache
           command: . scripts/cache_exclude_linux_no_sudo.sh
       - save_cache:
-          key: install-<< pipeline.parameters.LINUX_HPCKIT_URL >>-<< pipeline.parameters.LINUX_FORTRAN_COMPONENTS_WEB >>-compiler-${{ checksum "scripts/cache_exclude_linux_no_sudo.sh" }}
+          key: install-<< pipeline.parameters.LINUX_TOOLKIT_URL >>-<< pipeline.parameters.LINUX_FORTRAN_COMPONENTS_WEB >>-compiler-${{ checksum "scripts/cache_exclude_linux_no_sudo.sh" }}
           paths:
             - /opt/intel/oneapi/compiler
 
@@ -254,12 +248,12 @@ jobs:
           command: . scripts/install_prerequisites_linux_no_sudo.sh
       - restore_cache:
           keys:
-            - install-<< pipeline.parameters.LINUX_BASEKIT_URL >>-<< pipeline.parameters.LINUX_DPCPP_COMPONENTS_WEB >>-compiler-${{ checksum "scripts/cache_exclude_linux_no_sudo.sh" }}
+            - install-<< pipeline.parameters.LINUX_TOOLKIT_URL >>-<< pipeline.parameters.LINUX_DPCPP_COMPONENTS_WEB >>-compiler-${{ checksum "scripts/cache_exclude_linux_no_sudo.sh" }}
       - run:
           name: install
           command: |
            [ -d /opt/intel/oneapi/compiler ] && exit 0
-           . scripts/install_linux_no_sudo.sh << pipeline.parameters.LINUX_BASEKIT_URL >> << pipeline.parameters.LINUX_DPCPP_COMPONENTS_WEB >>
+           . scripts/install_linux_no_sudo.sh << pipeline.parameters.LINUX_TOOLKIT_URL >> << pipeline.parameters.LINUX_DPCPP_COMPONENTS_WEB >>
       - run:
           name: build
           command: scripts/build_linux.sh dpc++ << pipeline.parameters.SAMPLES_TAG >>
@@ -267,7 +261,7 @@ jobs:
           name: exclude unused files from cache
           command: . scripts/cache_exclude_linux_no_sudo.sh
       - save_cache:
-          key: install-<< pipeline.parameters.LINUX_BASEKIT_URL >>-<< pipeline.parameters.LINUX_DPCPP_COMPONENTS_WEB >>-compiler-tbb-${{ checksum "scripts/cache_exclude_linux_no_sudo.sh" }}
+          key: install-<< pipeline.parameters.LINUX_TOOLKIT_URL >>-<< pipeline.parameters.LINUX_DPCPP_COMPONENTS_WEB >>-compiler-tbb-${{ checksum "scripts/cache_exclude_linux_no_sudo.sh" }}
           paths:
             - /opt/intel/oneapi/compiler
             - /opt/intel/oneapi/tbb
@@ -483,7 +477,7 @@ jobs:
 
   build_linux_container_cpp:
     docker:
-      - image: intel/oneapi-hpckit
+      - image: intel/oneapi-toolkit
     steps:
       - run:
           name: install_git
@@ -495,7 +489,7 @@ jobs:
 
   build_linux_container_fortran:
     docker:
-      - image: intel/oneapi-hpckit
+      - image: intel/oneapi-toolkit
     steps:
       - run:
           name: install_git
@@ -507,7 +501,7 @@ jobs:
 
   build_linux_container_dpcpp:
     docker:
-      - image: intel/oneapi-basekit
+      - image: intel/oneapi-toolkit
     steps:
       - run:
           name: install_git

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -354,7 +354,7 @@ jobs:
 
   build_linux_dnf_cpp:
     runs-on: ubuntu-latest
-    container: fedora:37
+    container: fedora:43
     defaults:
       run:
         shell: bash
@@ -384,7 +384,7 @@ jobs:
 
   build_linux_dnf_fortran:
     runs-on: ubuntu-latest
-    container: fedora:37
+    container: fedora:43
     defaults:
       run:
         shell: bash
@@ -414,7 +414,7 @@ jobs:
 
   build_linux_dnf_dpcpp:
     runs-on: ubuntu-latest
-    container: fedora:37
+    container: fedora:43
     defaults:
       run:
         shell: bash

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -8,10 +8,8 @@ permissions: read-all
 on: push
 
 env:
-  WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/1f18901e-877d-469d-a41a-a10f11b39336/intel-oneapi-base-toolkit-2025.3.0.372_offline.exe
-  WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/3a871580-f839-46ed-aeae-685084127279/intel-oneapi-hpc-toolkit-2025.3.0.378_offline.exe
-  LINUX_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/d640da34-77cc-4ab2-8019-ac5592f4ec19/intel-oneapi-base-toolkit-2025.3.0.375_offline.sh
-  LINUX_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/66021d90-934d-41f4-bedf-b8c00bbe98bc/intel-oneapi-hpc-toolkit-2025.3.0.381_offline.sh
+  WINDOWS_TOOLKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/bae85ab1-cfcd-4251-8d42-a0c27949ea33/intel-oneapi-toolkit-2026.0.0.193_offline.exe
+  LINUX_TOOLKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/71180075-e4e3-4c6f-bbbb-19017ed0cf7d/intel-oneapi-toolkit-2026.0.0.198_offline.sh
   LINUX_AIKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/491d5c2a-67fe-48d0-884f-6aecd88f5d8a/ai-tools-2025.0.0.75_offline.sh
   WINDOWS_CPP_COMPONENTS: intel.oneapi.win.cpp-dpcpp-common
   WINDOWS_FORTRAN_COMPONENTS: intel.oneapi.win.ifort-compiler
@@ -22,11 +20,11 @@ env:
   LINUX_CPP_COMPONENTS_WEB: intel.oneapi.lin.dpcpp-cpp-compiler
   LINUX_FORTRAN_COMPONENTS_WEB: intel.oneapi.lin.ifort-compiler
   LINUX_DPCPP_COMPONENTS_WEB: intel.oneapi.lin.dpcpp-cpp-compiler
-  CACHE_NUMBER: 11
-  SAMPLES_TAG: 2025.3.0
+  CACHE_NUMBER: 12
+  SAMPLES_TAG: master
   AI_SAMPLES_TAG: 2025.0.0
-  COMPILER_VERSION: 2025.3
-  TBB_VERSION: 2022.3
+  COMPILER_VERSION: 2026.0
+  TBB_VERSION: 2023.0
   VS_VER: vs2022
 
 jobs:
@@ -44,10 +42,10 @@ jobs:
         path: |
             C:\Program Files (x86)\Intel\oneAPI\setvars-vcvarsall.bat
             C:\Program Files (x86)\Intel\oneAPI\compiler
-        key: install-${{ env.CACHE_NUMBER }}-${{ env.WINDOWS_HPCKIT_URL }}-${{ env.WINDOWS_CPP_COMPONENTS }}-compiler-${{ hashFiles('**/scripts/cache_exclude_windows.sh') }}
+        key: install-${{ env.CACHE_NUMBER }}-${{ env.WINDOWS_TOOLKIT_URL }}-${{ env.WINDOWS_CPP_COMPONENTS }}-compiler-${{ hashFiles('**/scripts/cache_exclude_windows.sh') }}
     - name: install
       if: steps.cache-install.outputs.cache-hit != 'true'
-      run: scripts/install_windows.bat $WINDOWS_HPCKIT_URL $WINDOWS_CPP_COMPONENTS
+      run: scripts/install_windows.bat $WINDOWS_TOOLKIT_URL $WINDOWS_CPP_COMPONENTS
     - name: build
       run: scripts/build_windows.bat c++ $VS_VER $SAMPLES_TAG
     - name: exclude unused files from cache
@@ -81,10 +79,10 @@ jobs:
         path: |
             C:\Program Files (x86)\Intel\oneAPI\setvars-vcvarsall.bat
             C:\Program Files (x86)\Intel\oneAPI\compiler
-        key: install-${{ env.CACHE_NUMBER }}-${{ env.WINDOWS_HPCKIT_URL }}-${{ env.WINDOWS_FORTRAN_COMPONENTS }}-compiler-${{ hashFiles('**/scripts/cache_exclude_windows.sh') }}
+        key: install-${{ env.CACHE_NUMBER }}-${{ env.WINDOWS_TOOLKIT_URL }}-${{ env.WINDOWS_FORTRAN_COMPONENTS }}-compiler-${{ hashFiles('**/scripts/cache_exclude_windows.sh') }}
     - name: install
       if: steps.cache-install.outputs.cache-hit != 'true'
-      run: scripts/install_windows.bat $WINDOWS_HPCKIT_URL $WINDOWS_FORTRAN_COMPONENTS
+      run: scripts/install_windows.bat $WINDOWS_TOOLKIT_URL $WINDOWS_FORTRAN_COMPONENTS
     - name: build
       run: scripts/build_windows.bat fortran $VS_VER $SAMPLES_TAG
     - name: exclude unused files from cache
@@ -120,10 +118,10 @@ jobs:
           C:\Program Files (x86)\Intel\oneAPI\compiler
           C:\Program Files (x86)\Intel\oneAPI\tbb
           C:\Windows\System32\OpenCL.dll
-        key: install-${{ env.CACHE_NUMBER }}-${{ env.WINDOWS_BASEKIT_URL }}-${{ env.WINDOWS_DPCPP_COMPONENTS }}-compiler-tbb-opencl-${{ hashFiles('**/scripts/cache_exclude_windows.sh') }}
+        key: install-${{ env.CACHE_NUMBER }}-${{ env.WINDOWS_TOOLKIT_URL }}-${{ env.WINDOWS_DPCPP_COMPONENTS }}-compiler-tbb-opencl-${{ hashFiles('**/scripts/cache_exclude_windows.sh') }}
     - name: install
       if: steps.cache-install.outputs.cache-hit != 'true'
-      run: scripts/install_windows.bat $WINDOWS_BASEKIT_URL $WINDOWS_DPCPP_COMPONENTS
+      run: scripts/install_windows.bat $WINDOWS_TOOLKIT_URL $WINDOWS_DPCPP_COMPONENTS
     - name: restore registry on cache hit
       if: steps.cache-install.outputs.cache-hit == 'true'
       run: scripts/restore_registry.bat $COMPILER_VERSION $TBB_VERSION
@@ -159,10 +157,10 @@ jobs:
       with:
         path: |
           /opt/intel/oneapi/compiler
-        key: install-${{ env.CACHE_NUMBER }}-${{ env.LINUX_HPCKIT_URL }}-${{ env.LINUX_CPP_COMPONENTS_WEB }}-compiler-${{ hashFiles('**/scripts/cache_exclude_linux.sh') }}
+        key: install-${{ env.CACHE_NUMBER }}-${{ env.LINUX_TOOLKIT_URL }}-${{ env.LINUX_CPP_COMPONENTS_WEB }}-compiler-${{ hashFiles('**/scripts/cache_exclude_linux.sh') }}
     - name: install
       if: steps.cache-install.outputs.cache-hit != 'true'
-      run: scripts/install_linux.sh $LINUX_HPCKIT_URL $LINUX_CPP_COMPONENTS_WEB
+      run: scripts/install_linux.sh $LINUX_TOOLKIT_URL $LINUX_CPP_COMPONENTS_WEB
     - name: build
       run: scripts/build_linux.sh c++ $SAMPLES_TAG
     - name: exclude unused files from cache
@@ -193,10 +191,10 @@ jobs:
       with:
         path: |
           /opt/intel/oneapi/compiler
-        key: install-${{ env.CACHE_NUMBER }}-${{ env.LINUX_HPCKIT_URL }}-${{ env.LINUX_FORTRAN_COMPONENTS_WEB }}-compiler-${{ hashFiles('**/scripts/cache_exclude_linux.sh') }}
+        key: install-${{ env.CACHE_NUMBER }}-${{ env.LINUX_TOOLKIT_URL }}-${{ env.LINUX_FORTRAN_COMPONENTS_WEB }}-compiler-${{ hashFiles('**/scripts/cache_exclude_linux.sh') }}
     - name: install
       if: steps.cache-install.outputs.cache-hit != 'true'
-      run: scripts/install_linux.sh $LINUX_HPCKIT_URL $LINUX_FORTRAN_COMPONENTS_WEB
+      run: scripts/install_linux.sh $LINUX_TOOLKIT_URL $LINUX_FORTRAN_COMPONENTS_WEB
     - name: build
       run: scripts/build_linux.sh fortran $SAMPLES_TAG
     - name: exclude unused files from cache
@@ -228,10 +226,10 @@ jobs:
         path: |
           /opt/intel/oneapi/compiler
           /opt/intel/oneapi/tbb
-        key: install-${{ env.CACHE_NUMBER }}-${{ env.LINUX_BASEKIT_URL }}-${{ env.LINUX_DPCPP_COMPONENTS_WEB }}-compiler-tbb-${{ hashFiles('**/scripts/cache_exclude_linux.sh') }}
+        key: install-${{ env.CACHE_NUMBER }}-${{ env.LINUX_TOOLKIT_URL }}-${{ env.LINUX_DPCPP_COMPONENTS_WEB }}-compiler-tbb-${{ hashFiles('**/scripts/cache_exclude_linux.sh') }}
     - name: install
       if: steps.cache-install.outputs.cache-hit != 'true'
-      run: scripts/install_linux.sh $LINUX_BASEKIT_URL $LINUX_DPCPP_COMPONENTS_WEB
+      run: scripts/install_linux.sh $LINUX_TOOLKIT_URL $LINUX_DPCPP_COMPONENTS_WEB
     - name: build
       run: scripts/build_linux.sh dpc++ $SAMPLES_TAG
     - name: exclude unused files from cache

--- a/.github/workflows/list_components.yml
+++ b/.github/workflows/list_components.yml
@@ -14,7 +14,7 @@ on:
 env:
   WINDOWS_TOOLKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/bae85ab1-cfcd-4251-8d42-a0c27949ea33/intel-oneapi-toolkit-2026.0.0.193.exe
   LINUX_TOOLKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/71180075-e4e3-4c6f-bbbb-19017ed0cf7d/intel-oneapi-toolkit-2026.0.0.198.sh
-  
+
 jobs:
   windows:
     runs-on: windows-latest

--- a/.github/workflows/list_components.yml
+++ b/.github/workflows/list_components.yml
@@ -12,10 +12,8 @@ on:
     - cron: '0 0 * * *'
 
 env:
-  WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/1f18901e-877d-469d-a41a-a10f11b39336/intel-oneapi-base-toolkit-2025.3.0.372.exe
-  WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/3a871580-f839-46ed-aeae-685084127279/intel-oneapi-hpc-toolkit-2025.3.0.378.exe
-  LINUX_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/d640da34-77cc-4ab2-8019-ac5592f4ec19/intel-oneapi-base-toolkit-2025.3.0.375.sh
-  LINUX_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/66021d90-934d-41f4-bedf-b8c00bbe98bc/intel-oneapi-hpc-toolkit-2025.3.0.381.sh
+  WINDOWS_TOOLKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/bae85ab1-cfcd-4251-8d42-a0c27949ea33/intel-oneapi-toolkit-2026.0.0.193.exe
+  LINUX_TOOLKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/71180075-e4e3-4c6f-bbbb-19017ed0cf7d/intel-oneapi-toolkit-2026.0.0.198.sh
   
 jobs:
   windows:
@@ -28,16 +26,14 @@ jobs:
     - uses: actions/setup-python@v3
       with:
         python-version: '3.x'
-    - name: Intel® oneAPI Base Toolkit
-      run: scripts/list_components_windows.bat $WINDOWS_BASEKIT_URL doc\\source\\${{ github.workflow }}\\${{ github.job }}_basekit.txt
-    - name: Intel® oneAPI HPC Toolkit
-      run: scripts/list_components_windows.bat $WINDOWS_HPCKIT_URL doc\\source\\${{ github.workflow }}\\${{ github.job }}_hpckit.txt
+    - name: Intel® oneAPI Toolkit
+      run: scripts/list_components_windows.bat $WINDOWS_TOOLKIT_URL doc\\source\\${{ github.workflow }}\\${{ github.job }}.txt
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
         name: ${{ github.job }}
-        path: doc/source/${{ github.workflow }}/${{ github.job }}_*
+        path: doc/source/${{ github.workflow }}/${{ github.job }}.txt
 
   linux:
     runs-on: ubuntu-latest
@@ -49,15 +45,13 @@ jobs:
     - uses: actions/setup-python@v3
       with:
         python-version: '3.x'
-    - name: Intel® oneAPI Base Toolkit
-      run: scripts/list_components_linux.sh $LINUX_BASEKIT_URL doc/source/${{ github.workflow }}/${{ github.job }}_basekit.txt
-    - name: Intel® oneAPI HPC Toolkit
-      run: scripts/list_components_linux.sh $LINUX_HPCKIT_URL doc/source/${{ github.workflow }}/${{ github.job }}_hpckit.txt
+    - name: Intel® oneAPI Toolkit
+      run: scripts/list_components_linux.sh $LINUX_TOOLKIT_URL doc/source/${{ github.workflow }}/${{ github.job }}.txt
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
         name: ${{ github.job }}
-        path: doc/source/${{ github.workflow }}/${{ github.job }}_*
+        path: doc/source/${{ github.workflow }}/${{ github.job }}.txt
 
   linux_apt:
     runs-on: ubuntu-latest

--- a/.github/workflows/list_components.yml
+++ b/.github/workflows/list_components.yml
@@ -76,7 +76,7 @@ jobs:
 
   linux_yum_dnf:
     runs-on: ubuntu-latest
-    container: fedora:37
+    container: fedora:43
     defaults:
       run:
         shell: bash

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,10 +6,8 @@ stages:
   - build
 
 variables:
-  WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/1f18901e-877d-469d-a41a-a10f11b39336/intel-oneapi-base-toolkit-2025.3.0.372_offline.exe
-  WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/3a871580-f839-46ed-aeae-685084127279/intel-oneapi-hpc-toolkit-2025.3.0.378_offline.exe
-  LINUX_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/d640da34-77cc-4ab2-8019-ac5592f4ec19/intel-oneapi-base-toolkit-2025.3.0.375_offline.sh
-  LINUX_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/66021d90-934d-41f4-bedf-b8c00bbe98bc/intel-oneapi-hpc-toolkit-2025.3.0.381_offline.sh
+  WINDOWS_TOOLKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/bae85ab1-cfcd-4251-8d42-a0c27949ea33/intel-oneapi-toolkit-2026.0.0.193_offline.exe
+  LINUX_TOOLKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/71180075-e4e3-4c6f-bbbb-19017ed0cf7d/intel-oneapi-toolkit-2026.0.0.198_offline.sh
   WINDOWS_CPP_COMPONENTS: intel.oneapi.win.cpp-compiler
   WINDOWS_FORTRAN_COMPONENTS: intel.oneapi.win.ifort-compiler
   WINDOWS_DPCPP_COMPONENTS: intel.oneapi.win.dpcpp-compiler
@@ -19,10 +17,10 @@ variables:
   LINUX_CPP_COMPONENTS_WEB: intel.oneapi.lin.dpcpp-cpp-compiler-pro
   LINUX_FORTRAN_COMPONENTS_WEB: intel.oneapi.lin.ifort-compiler
   LINUX_DPCPP_COMPONENTS_WEB: intel.oneapi.lin.dpcpp-cpp-compiler
-  CACHE_NUMBER: 11
-  SAMPLES_TAG: 2025.3.0
-  COMPILER_VERSION: "2025.3"
-  TBB_VERSION: "2022.3"
+  CACHE_NUMBER: 12
+  SAMPLES_TAG: master
+  COMPILER_VERSION: "2026.0"
+  TBB_VERSION: "2023.0"
   VS_VER: 2019_build_tools
 
 .shared_windows_runners:
@@ -49,7 +47,7 @@ build_windows_cpp:
           Move-Item -Path cache\compiler -Destination "C:\Program Files (x86)\Intel\oneAPI"
           Move-Item -Path cache\setvars-vcvarsall.bat -Destination "C:\Program Files (x86)\Intel\oneAPI\setvars-vcvarsall.bat"
         } else {
-          scripts/install_windows.bat $WINDOWS_HPCKIT_URL $WINDOWS_CPP_COMPONENTS
+          scripts/install_windows.bat $WINDOWS_TOOLKIT_URL $WINDOWS_CPP_COMPONENTS
         }
   script:
     - scripts/build_windows.bat c++ ${VS_VER} ${SAMPLES_TAG}
@@ -91,7 +89,7 @@ build_windows_fortran:
           Move-Item -Path cache\compiler -Destination "C:\Program Files (x86)\Intel\oneAPI"
           Move-Item -Path cache\setvars-vcvarsall.bat -Destination "C:\Program Files (x86)\Intel\oneAPI\setvars-vcvarsall.bat"
         } else {
-          scripts/install_windows.bat $WINDOWS_HPCKIT_URL $WINDOWS_FORTRAN_COMPONENTS
+          scripts/install_windows.bat $WINDOWS_TOOLKIT_URL $WINDOWS_FORTRAN_COMPONENTS
         }
   script:
     - scripts/build_windows.bat fortran ${VS_VER} ${SAMPLES_TAG}
@@ -134,7 +132,7 @@ build_windows_dpcpp:
           Move-Item -Path cache\setvars-vcvarsall.bat -Destination "C:\Program Files (x86)\Intel\oneAPI\setvars-vcvarsall.bat"
           scripts/restore_registry.bat $COMPILER_VERSION $TBB_VERSION
         } else {
-          scripts/install_windows.bat $WINDOWS_BASEKIT_URL $WINDOWS_DPCPP_COMPONENTS
+          scripts/install_windows.bat $WINDOWS_TOOLKIT_URL $WINDOWS_DPCPP_COMPONENTS
         }
   script:
     - scripts/build_windows.bat dpc++ ${VS_VER} ${SAMPLES_TAG}
@@ -163,7 +161,7 @@ build_linux_cpp:
   stage: build
   cache:
     key: # GitLab CI doesn't support steps before cache is restored, i.e. only static cache keys are supported.
-      prefix: install-${LINUX_HPCKIT_URL}-${LINUX_CPP_COMPONENTS_WEB}-compiler
+      prefix: install-${LINUX_TOOLKIT_URL}-${LINUX_CPP_COMPONENTS_WEB}-compiler
       files:
         - scripts/cache_exclude_linux_no_sudo.sh
     paths:
@@ -176,7 +174,7 @@ build_linux_cpp:
           mkdir -p /opt/intel/oneapi
           mv cache/compiler /opt/intel/oneapi/
         else
-          . scripts/install_linux_no_sudo.sh $LINUX_HPCKIT_URL $LINUX_CPP_COMPONENTS_WEB
+          . scripts/install_linux_no_sudo.sh $LINUX_TOOLKIT_URL $LINUX_CPP_COMPONENTS_WEB
         fi
   script:
     - scripts/build_linux.sh c++ ${SAMPLES_TAG}
@@ -202,7 +200,7 @@ build_linux_fortran:
   stage: build
   cache:
     key: # GitLab CI doesn't support steps before cache is restored, i.e. only static cache keys are supported.
-      prefix: install-${LINUX_HPCKIT_URL}-${LINUX_FORTRAN_COMPONENTS_WEB}-compiler
+      prefix: install-${LINUX_TOOLKIT_URL}-${LINUX_FORTRAN_COMPONENTS_WEB}-compiler
       files:
         - scripts/cache_exclude_linux_no_sudo.sh
     paths:
@@ -215,7 +213,7 @@ build_linux_fortran:
           mkdir -p /opt/intel/oneapi
           mv cache/compiler /opt/intel/oneapi/
         else
-          . scripts/install_linux_no_sudo.sh $LINUX_HPCKIT_URL $LINUX_FORTRAN_COMPONENTS_WEB
+          . scripts/install_linux_no_sudo.sh $LINUX_TOOLKIT_URL $LINUX_FORTRAN_COMPONENTS_WEB
         fi
   script:
     - scripts/build_linux.sh fortran ${SAMPLES_TAG}
@@ -241,7 +239,7 @@ build_linux_dpcpp:
   stage: build
   cache:
     key: # GitLab CI doesn't support steps before cache is restored, i.e. only static cache keys are supported.
-      prefix: install-${LINUX_BASEKIT_URL}-${LINUX_DPCPP_COMPONENTS_WEB}-compiler-tbb
+      prefix: install-${LINUX_TOOLKIT_URL}-${LINUX_DPCPP_COMPONENTS_WEB}-compiler-tbb
       files:
         - scripts/cache_exclude_linux_no_sudo.sh
     paths:
@@ -255,7 +253,7 @@ build_linux_dpcpp:
           mv cache/compiler /opt/intel/oneapi/
           mv cache/tbb /opt/intel/oneapi/
         else
-          . scripts/install_linux_no_sudo.sh $LINUX_BASEKIT_URL $LINUX_DPCPP_COMPONENTS_WEB
+          . scripts/install_linux_no_sudo.sh $LINUX_TOOLKIT_URL $LINUX_DPCPP_COMPONENTS_WEB
         fi
   script:
     - scripts/build_linux.sh dpc++ ${SAMPLES_TAG}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -374,7 +374,7 @@ build_linux_apt_dpcpp:
         mv /opt/intel/oneapi/tbb cache
 
 build_linux_dnf_cpp:
-  image: fedora:37
+  image: fedora:43
   stage: build
   cache:
     key: # GitLab CI doesn't support steps before cache is restored, i.e. only static cache keys are supported.
@@ -406,7 +406,7 @@ build_linux_dnf_cpp:
         mv /opt/intel/oneapi/compiler cache
 
 build_linux_dnf_fortran:
-  image: fedora:37
+  image: fedora:43
   stage: build
   cache:
     key:
@@ -438,7 +438,7 @@ build_linux_dnf_fortran:
         mv /opt/intel/oneapi/compiler cache
 
 build_linux_dnf_dpcpp:
-  image: fedora:37
+  image: fedora:43
   stage: build
   cache:
     key:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ def SAMPLES_REPO = "https://github.com/oneapi-src/oneAPI-samples.git"
 def SAMPLES_TAG = "2023.2.0"
 
 pipeline {
-  agent { docker { image 'intel/oneapi-hpckit' } }
+  agent { docker { image 'intel/oneapi-toolkit' } }
   stages {
     stage('checkout samples') {
       steps {

--- a/scripts/dnf_depends.sh
+++ b/scripts/dnf_depends.sh
@@ -4,4 +4,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-echo "$1" | sed "s/,/ /g" | xargs -n 1 dnf -y repoquery --deplist
+echo "$1" | sed "s/,/ /g" | xargs -n 1 dnf -y repoquery --requires --resolve

--- a/scripts/dnf_depends.sh
+++ b/scripts/dnf_depends.sh
@@ -4,4 +4,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-echo "$1" | sed "s/,/ /g" | xargs -n 1 dnf -y repoquery --requires --resolve
+echo "$1" | sed "s/,/ /g" | xargs -n 1 dnf -y repoquery --requires


### PR DESCRIPTION
 Updated component versions to 2026.0 and adjusted sample tags to 'master' for consistency across all configurations.